### PR TITLE
Add GitLab CI exmaple for a gitlab runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,10 @@
+stages:
+  - build
+
+build:
+  stage: build
+  script:
+    - python tail-serial-port.py -p /dev/ttys001 -o output.txt
+  artifacts:
+    paths:
+      - output.txt

--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ options:
                         Set serial stopbits (e.g., -s=1)
 ```
 
+## Example gitlab-ci
+
+You can fine an example of a .gitlab-ci in [.gitlab-ci](.gitlab.ci).
+
+Just be mindful that you probably need to change the file and port parameters.
+
 ## Sources
 
 https://pyserial.readthedocs.io/en/latest/shortintro.html


### PR DESCRIPTION
## Background / Context

A good practice is to have tests in every repo and have automation as well.

## Aim / Implementation

That is why, I am leaving an example of a GitLab CI definition that can be used in gitlab with this tool.

For more info - check the README.md
